### PR TITLE
chore: Add workflows to manage issue status

### DIFF
--- a/.github/workflows/set-issue-in-progress.yml
+++ b/.github/workflows/set-issue-in-progress.yml
@@ -1,0 +1,111 @@
+# Based on https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions
+name: 🗂 Set issue status
+on:
+  issues:
+    types: [assigned, unassigned]
+jobs:
+  track_pr:
+    name: Set to 🏗 In Progress / 🔖 Ready
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTH_TOKEN }}
+          USER: ${{github.repository_owner}}
+          PROJECT_NUMBER: 2
+          ISSUE_ID: ${{ github.event.issue.node_id   }}
+        run: |
+          gh api graphql -f query='
+            query($user: String!, $number: Int!, $issue:ID!) {
+              node(id: $issue) {
+                ... on Issue {
+                  projectItems(first:1) {
+                    nodes {
+                      id
+                    }
+                  }
+                }
+              }
+              user(login: $user){
+                projectV2(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      ... on ProjectV2Field {
+                        id
+                        name
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f user=$USER -F number=$PROJECT_NUMBER -f issue=$ISSUE_ID > project_data.json
+
+          echo 'PROJECT_ID='$(jq '.data.user.projectV2.id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq '.data.user.projectV2.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+          # Using jq -r here because IN_PROGRESS_OPTION_ID is an Int and we need to keep it like that instead of letting jq return a String
+          echo 'IN_PROGRESS_OPTION_ID='$(jq -r '.data.user.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="🏗 In progress") |.id' project_data.json) >> $GITHUB_ENV
+          echo 'READY_OPTION_ID='$(jq -r '.data.user.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="🔖 Ready") |.id' project_data.json) >> $GITHUB_ENV
+          echo 'LINKED_ISSUE_ID='$(jq '.data.node.projectItems.nodes[0].id' project_data.json) >> $GITHUB_ENV
+
+      - name: Move to 🏗 In Progress
+        if: ${{ toJson(github.event.issue.assignees.*.login) != 'null' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTH_TOKEN }}
+        run: |
+          echo 'Move to 🏗 In Progress'
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+            ) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: {
+                  singleSelectOptionId: $status_value
+                }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f item=$LINKED_ISSUE_ID -f status_field=$STATUS_FIELD_ID -f status_value=$IN_PROGRESS_OPTION_ID
+
+      - name: Move to 🔖 Ready
+        if: ${{ toJson(github.event.issue.assignees.*.login) == 'null' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTH_TOKEN }}
+        run: |
+          echo 'Move to 🔖 Ready'
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+            ) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: {
+                  singleSelectOptionId: $status_value
+                }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f item=$LINKED_ISSUE_ID -f status_field=$STATUS_FIELD_ID -f status_value=$READY_OPTION_ID

--- a/.github/workflows/set-issue-in-review.yml
+++ b/.github/workflows/set-issue-in-review.yml
@@ -1,0 +1,87 @@
+# Based on https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions
+name: 🗂 Set issue status
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, edited, ready_for_review, synchronize]
+jobs:
+  track_pr:
+    name: Set to 👀 In Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTH_TOKEN }}
+          USER: ${{github.repository_owner}}
+          PROJECT_NUMBER: 2
+          PR_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          gh api graphql -f query='
+            query($user: String!, $number: Int!, $pr:ID!) {
+              node(id: $pr) {
+                ... on PullRequest {
+                  closingIssuesReferences(first:1, userLinkedOnly:false) {
+                    nodes {
+                      projectItems(first:1) {
+                        nodes {
+                          id
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              user(login: $user){
+                projectV2(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      ... on ProjectV2Field {
+                        id
+                        name
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f user=$USER -F number=$PROJECT_NUMBER -f pr=$PR_ID > project_data.json
+
+          echo 'PROJECT_ID='$(jq '.data.user.projectV2.id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq '.data.user.projectV2.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+          # Using jq -r here because IN_REVIEW_OPTION_ID is an Int and we need to keep it like that instead of letting jq return a String
+          echo 'IN_REVIEW_OPTION_ID='$(jq -r '.data.user.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="👀 In review") |.id' project_data.json) >> $GITHUB_ENV
+          echo 'LINKED_ISSUE_ID='$(jq '.data.node.closingIssuesReferences.nodes[0].projectItems.nodes[0].id' project_data.json) >> $GITHUB_ENV
+
+      - name: Move to 👀 In review
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTH_TOKEN }}
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+            ) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: {
+                  singleSelectOptionId: $status_value
+                }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f item=$LINKED_ISSUE_ID -f status_field=$STATUS_FIELD_ID -f status_value=$IN_REVIEW_OPTION_ID

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ node_modules
 
 # Easy way to create temporary files/folders that won't accidentally be added to git
 *.local.*
+
+# act testing input
+act_testing.json


### PR DESCRIPTION
## Description

Add two new workflows:
1. `Set issue 🏗 In Progress / 🔖 Ready`: Moves issues to `🏗 In progress` or `🔖 Ready`, depending on whether assignees are set or unset.
1. `Set issue to 👀 In Review`: Move issues to `👀 In Review` when a Pull Request is open to close an issue.

Closes #16 