### PR TITLE
chore: Remove usages of getSitemapEntries

### DIFF
--- a/app/routes/admin+/cache.tsx
+++ b/app/routes/admin+/cache.tsx
@@ -24,12 +24,7 @@ import {
 } from "#app/utils/misc.tsx";
 import { requireUserWithRole } from "#app/utils/permissions.ts";
 
-import type { SEOHandle } from "@nasa-gcn/remix-seo";
 import type { DataFunctionArgs } from "@remix-run/node";
-
-export const handle: SEOHandle = {
-  getSitemapEntries: () => null,
-};
 
 export async function loader({ request }: DataFunctionArgs) {
   await requireUserWithRole(request, "admin");

--- a/app/routes/settings+/profile.change-email.tsx
+++ b/app/routes/settings+/profile.change-email.tsx
@@ -22,15 +22,13 @@ import { redirectWithToast } from "#app/utils/toast.server.ts";
 import { EmailSchema } from "#app/utils/user-validation.ts";
 import { verifySessionStorage } from "#app/utils/verification.server.ts";
 
-import type { SEOHandle } from "@nasa-gcn/remix-seo";
 import type { DataFunctionArgs } from "@remix-run/node";
 import type { VerifyFunctionArgs } from "#app/routes/_auth+/verify.tsx";
 
 import type { BreadcrumbHandle } from "./profile.tsx";
 
-export const handle: BreadcrumbHandle & SEOHandle = {
+export const handle: BreadcrumbHandle = {
   breadcrumb: <Icon name="envelope-closed">Change Email</Icon>,
-  getSitemapEntries: () => null,
 };
 
 export const newEmailAddressSessionKey = "new-email-address";

--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -23,12 +23,7 @@ import { NameSchema, UsernameSchema } from "#app/utils/user-validation.ts";
 
 import { twoFAVerificationType } from "./profile.two-factor.tsx";
 
-import type { SEOHandle } from "@nasa-gcn/remix-seo";
 import type { DataFunctionArgs } from "@remix-run/node";
-
-export const handle: SEOHandle = {
-  getSitemapEntries: () => null,
-};
 
 const ProfileFormSchema = z.object({
   name: NameSchema.optional(),

--- a/app/routes/settings+/profile.password.tsx
+++ b/app/routes/settings+/profile.password.tsx
@@ -20,14 +20,12 @@ import { useIsPending } from "#app/utils/misc.tsx";
 import { redirectWithToast } from "#app/utils/toast.server.ts";
 import { PasswordSchema } from "#app/utils/user-validation.ts";
 
-import type { SEOHandle } from "@nasa-gcn/remix-seo";
 import type { DataFunctionArgs } from "@remix-run/node";
 
 import type { BreadcrumbHandle } from "./profile.tsx";
 
-export const handle: BreadcrumbHandle & SEOHandle = {
+export const handle: BreadcrumbHandle = {
   breadcrumb: <Icon name="dots-horizontal">Password</Icon>,
-  getSitemapEntries: () => null,
 };
 
 const ChangePasswordForm = z

--- a/app/routes/settings+/profile.password_.create.tsx
+++ b/app/routes/settings+/profile.password_.create.tsx
@@ -12,14 +12,12 @@ import { prisma } from "#app/utils/db.server.ts";
 import { useIsPending } from "#app/utils/misc.tsx";
 import { PasswordAndConfirmPasswordSchema } from "#app/utils/user-validation.ts";
 
-import type { SEOHandle } from "@nasa-gcn/remix-seo";
 import type { DataFunctionArgs } from "@remix-run/node";
 
 import type { BreadcrumbHandle } from "./profile.tsx";
 
-export const handle: BreadcrumbHandle & SEOHandle = {
+export const handle: BreadcrumbHandle = {
   breadcrumb: <Icon name="dots-horizontal">Password</Icon>,
-  getSitemapEntries: () => null,
 };
 
 const CreatePasswordForm = PasswordAndConfirmPasswordSchema;

--- a/app/routes/settings+/profile.photo.tsx
+++ b/app/routes/settings+/profile.photo.tsx
@@ -30,14 +30,12 @@ import {
   useIsPending,
 } from "#app/utils/misc.tsx";
 
-import type { SEOHandle } from "@nasa-gcn/remix-seo";
 import type { DataFunctionArgs } from "@remix-run/node";
 
 import type { BreadcrumbHandle } from "./profile.tsx";
 
-export const handle: BreadcrumbHandle & SEOHandle = {
+export const handle: BreadcrumbHandle = {
   breadcrumb: <Icon name="avatar">Photo</Icon>,
-  getSitemapEntries: () => null,
 };
 
 const MAX_SIZE = 1024 * 1024 * 3; // 3MB

--- a/app/routes/settings+/profile.tsx
+++ b/app/routes/settings+/profile.tsx
@@ -9,15 +9,13 @@ import { prisma } from "#app/utils/db.server.ts";
 import { cn, invariantResponse } from "#app/utils/misc.tsx";
 import { useUser } from "#app/utils/user.ts";
 
-import type { SEOHandle } from "@nasa-gcn/remix-seo";
 import type { DataFunctionArgs } from "@remix-run/node";
 
 export const BreadcrumbHandle = z.object({ breadcrumb: z.any() });
 export type BreadcrumbHandle = z.infer<typeof BreadcrumbHandle>;
 
-export const handle: BreadcrumbHandle & SEOHandle = {
+export const handle: BreadcrumbHandle = {
   breadcrumb: <Icon name="file-text">Edit Profile</Icon>,
-  getSitemapEntries: () => null,
 };
 
 export async function loader({ request }: DataFunctionArgs) {

--- a/app/routes/settings+/profile.two-factor.disable.tsx
+++ b/app/routes/settings+/profile.two-factor.disable.tsx
@@ -13,14 +13,12 @@ import { redirectWithToast } from "#app/utils/toast.server.ts";
 
 import { twoFAVerificationType } from "./profile.two-factor.tsx";
 
-import type { SEOHandle } from "@nasa-gcn/remix-seo";
 import type { DataFunctionArgs } from "@remix-run/node";
 
 import type { BreadcrumbHandle } from "./profile.tsx";
 
-export const handle: BreadcrumbHandle & SEOHandle = {
+export const handle: BreadcrumbHandle = {
   breadcrumb: <Icon name="lock-open-1">Disable</Icon>,
-  getSitemapEntries: () => null,
 };
 
 export async function loader({ request }: DataFunctionArgs) {

--- a/app/routes/settings+/profile.two-factor.index.tsx
+++ b/app/routes/settings+/profile.two-factor.index.tsx
@@ -12,12 +12,7 @@ import { generateTOTP } from "#app/utils/totp.server.ts";
 import { twoFAVerificationType } from "./profile.two-factor.tsx";
 import { twoFAVerifyVerificationType } from "./profile.two-factor.verify.tsx";
 
-import type { SEOHandle } from "@nasa-gcn/remix-seo";
 import type { DataFunctionArgs } from "@remix-run/node";
-
-export const handle: SEOHandle = {
-  getSitemapEntries: () => null,
-};
 
 export async function loader({ request }: DataFunctionArgs) {
   const userId = await requireUserId(request);

--- a/app/routes/settings+/profile.two-factor.tsx
+++ b/app/routes/settings+/profile.two-factor.tsx
@@ -2,14 +2,12 @@ import { Outlet } from "@remix-run/react";
 
 import { Icon } from "#app/components/ui/icon.tsx";
 
-import type { SEOHandle } from "@nasa-gcn/remix-seo";
 import type { VerificationTypes } from "#app/routes/_auth+/verify.tsx";
 
 import type { BreadcrumbHandle } from "./profile.tsx";
 
-export const handle: BreadcrumbHandle & SEOHandle = {
+export const handle: BreadcrumbHandle = {
   breadcrumb: <Icon name="lock-closed">2FA</Icon>,
-  getSitemapEntries: () => null,
 };
 
 export const twoFAVerificationType = "2fa" satisfies VerificationTypes;

--- a/app/routes/settings+/profile.two-factor.verify.tsx
+++ b/app/routes/settings+/profile.two-factor.verify.tsx
@@ -24,14 +24,12 @@ import { getTOTPAuthUri } from "#app/utils/totp.server.ts";
 
 import { twoFAVerificationType } from "./profile.two-factor.tsx";
 
-import type { SEOHandle } from "@nasa-gcn/remix-seo";
 import type { DataFunctionArgs } from "@remix-run/node";
 
 import type { BreadcrumbHandle } from "./profile.tsx";
 
-export const handle: BreadcrumbHandle & SEOHandle = {
+export const handle: BreadcrumbHandle = {
   breadcrumb: <Icon name="check">Verify</Icon>,
-  getSitemapEntries: () => null,
 };
 
 const CancelSchema = z.object({ intent: z.literal("cancel") });


### PR DESCRIPTION


## Description

`getSitemapEntries` should not be needed, as we do not generate sitemaps anymore.


Closes #79 
