### PR TITLE
fix: Fix module resolution config

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -139,7 +139,6 @@ export async function loader({ request }: DataFunctionArgs) {
     {
       user,
       requestInfo: {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         hints: getHints(request),
         origin: getDomainUrl(request),
         path: new URL(request.url).pathname,
@@ -232,11 +231,9 @@ function App() {
   const data = useLoaderData<typeof loader>();
   const nonce = useNonce();
   const user = useOptionalUser();
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const theme = useTheme();
 
   return (
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     <Document env={data.ENV} nonce={nonce} theme={theme}>
       <div className="flex h-screen flex-col justify-between">
         <header className="container py-6">
@@ -350,15 +347,12 @@ function UserDropdown() {
  * has not set a preference.
  */
 export function useTheme() {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const hints = useHints();
   const requestInfo = useRequestInfo();
   const optimisticMode = useOptimisticThemeMode();
   if (optimisticMode) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     return optimisticMode === "system" ? hints.theme : optimisticMode;
   }
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
   return requestInfo.userPrefs.theme ?? hints.theme;
 }
 

--- a/app/utils/client-hints.tsx
+++ b/app/utils/client-hints.tsx
@@ -26,7 +26,6 @@ export const { getHints } = hintsUtils;
  */
 export function useHints() {
   const requestInfo = useRequestInfo();
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return requestInfo.hints;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,8 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
     "noEmit": true,
     "noImplicitAny": true,
     "paths": {


### PR DESCRIPTION


## Description
Fix the module resolution config and remove the now unnecessary `eslint-disable-next-line` directives related with `@epic-web/client-hints`.

Closes #93 
