### PR TITLE
feat: Add main layout for the application

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -28,6 +28,8 @@ export default {
     "",
     "<TYPES>",
     "",
+    "<TYPES>^[#]",
+    "",
     "<TYPES>^[./]",
   ],
 };

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "tailwindCSS.experimental.classRegex": [
+    ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
+    ["cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+  ],
   "typescript.preferences.autoImportFileExcludePatterns": [
     "@remix-run/server-runtime",
     "@remix-run/router",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
     "console",
     "node:console"
   ],
+  "typescript.preferences.importModuleSpecifier": "non-relative",
   "typescript.tsdk": "node_modules/typescript/lib",
   "workbench.editorAssociations": {
     "*.db": "sqlite-viewer.view"

--- a/app/components/ui/layout/flex.tsx
+++ b/app/components/ui/layout/flex.tsx
@@ -1,0 +1,95 @@
+import { cva } from "class-variance-authority";
+import { forwardRef } from "react";
+
+import { cn } from "#app/utils/misc";
+
+import type { VariantProps } from "class-variance-authority";
+import type { HTMLAttributes } from "react";
+
+const flexVariants = cva("box-border flex flex-1", {
+  variants: {
+    direction: {
+      row: "flex-row",
+      column: "flex-col",
+    },
+    align: {
+      start: "items-start",
+      center: "items-center",
+      end: "items-end",
+      stretch: "items-stretch",
+    },
+    justify: {
+      start: "justify-start",
+      center: "justify-center",
+      end: "justify-end",
+      between: "justify-between",
+      around: "justify-around",
+      evenly: "justify-evenly",
+    },
+    wrap: {
+      wrap: "flex-wrap",
+      nowrap: "flex-nowrap",
+    },
+    gap: {
+      none: "gap-0",
+      tiny: "gap-0.5",
+      small: "gap-1",
+      medium: "gap-2",
+      large: "gap-3",
+      xlarge: "gap-4",
+      ["2xlarge"]: "gap-5",
+    },
+    grow: {
+      0: "flex-grow-0",
+      1: "flex-grow",
+    },
+  },
+  defaultVariants: {
+    direction: "row",
+    align: "start",
+    justify: "start",
+    wrap: "nowrap",
+    gap: "medium",
+  },
+});
+
+// Need to use interface here: https://github.com/shadcn-ui/ui/issues/120
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export interface FlexProps
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof flexVariants> {
+  as?: "div" | "main" | "nav" | "section" | "header";
+}
+
+export const Flex = forwardRef<HTMLDivElement, FlexProps>(
+  (
+    {
+      as: Component = "div",
+      children,
+      align,
+      direction,
+      gap,
+      grow,
+      justify,
+      wrap,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <Component
+        ref={ref}
+        className={cn(
+          flexVariants({ align, direction, gap, grow, justify, wrap }),
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </Component>
+    );
+  },
+);
+
+Flex.displayName = "Flex";

--- a/app/components/ui/layout/index.ts
+++ b/app/components/ui/layout/index.ts
@@ -1,0 +1,7 @@
+export { Inline } from "./inline";
+export { Flex } from "./flex";
+export { Stack } from "./stack";
+
+export type { InlineProps } from "./inline";
+export type { FlexProps } from "./flex";
+export type { StackProps } from "./stack";

--- a/app/components/ui/layout/inline.tsx
+++ b/app/components/ui/layout/inline.tsx
@@ -1,0 +1,21 @@
+import { forwardRef } from "react";
+
+import { Flex } from ".";
+
+import type { FlexProps } from ".";
+
+// Need to use interface here: https://github.com/shadcn-ui/ui/issues/120
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export interface InlineProps extends Omit<FlexProps, "direction"> {}
+
+export const Inline = forwardRef<HTMLDivElement, InlineProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <Flex ref={ref} direction="row" gap="small" {...props}>
+        {children}
+      </Flex>
+    );
+  },
+);
+
+Inline.displayName = "Inline";

--- a/app/components/ui/layout/stack.tsx
+++ b/app/components/ui/layout/stack.tsx
@@ -1,0 +1,21 @@
+import { forwardRef } from "react";
+
+import { Flex } from ".";
+
+import type { FlexProps } from ".";
+
+// Need to use interface here: https://github.com/shadcn-ui/ui/issues/120
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export interface StackProps extends Omit<FlexProps, "direction"> {}
+
+export const Stack = forwardRef<HTMLDivElement, StackProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <Flex ref={ref} direction="column" gap="medium" {...props}>
+        {children}
+      </Flex>
+    );
+  },
+);
+
+Stack.displayName = "Stack";

--- a/app/layout/document.tsx
+++ b/app/layout/document.tsx
@@ -1,0 +1,49 @@
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Scripts,
+  ScrollRestoration,
+} from "@remix-run/react";
+
+import { ClientHintCheck } from "#app/utils/client-hints.tsx";
+
+import type { Theme } from "#app/theme/types";
+
+type DocumentProps = {
+  children: React.ReactNode;
+  nonce: string;
+  theme?: Theme;
+  env?: Record<string, string>;
+};
+
+export const Document = ({
+  children,
+  nonce,
+  theme = "light",
+  env = {},
+}: DocumentProps) => {
+  return (
+    <html className={`${theme} h-full overflow-x-hidden`} lang="en">
+      <head>
+        <ClientHintCheck nonce={nonce} />
+        <Meta />
+        <meta charSet="utf-8" />
+        <meta content="width=device-width,initial-scale=1" name="viewport" />
+        <Links />
+      </head>
+      <body className="bg-background text-foreground">
+        {children}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.ENV = ${JSON.stringify(env)}`,
+          }}
+          nonce={nonce}
+        />
+        <ScrollRestoration nonce={nonce} />
+        <Scripts nonce={nonce} />
+        <LiveReload nonce={nonce} />
+      </body>
+    </html>
+  );
+};

--- a/app/routes/settings+/profile.change-email.tsx
+++ b/app/routes/settings+/profile.change-email.tsx
@@ -21,6 +21,7 @@ import { EmailSchema } from "#app/utils/user-validation.ts";
 import { verifySessionStorage } from "#app/utils/verification.server.ts";
 
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
+
 import type { VerifyFunctionArgs } from "#app/routes/_auth+/verify.tsx";
 
 import type { BreadcrumbHandle } from "./profile.tsx";

--- a/app/theme/schema.ts
+++ b/app/theme/schema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const ThemeFormSchema = z.object({
+  theme: z.enum(["system", "light", "dark"]),
+});

--- a/app/theme/theme-switch.tsx
+++ b/app/theme/theme-switch.tsx
@@ -1,0 +1,76 @@
+import { useForm } from "@conform-to/react";
+
+import { useOptimisticThemeMode } from "#app/theme/useOptimisticThemeMode";
+
+import { ErrorList } from "../components/forms";
+import { Icon } from "../components/ui/icon";
+
+import type { Submission } from "@conform-to/react";
+import type { FetcherWithComponents } from "@remix-run/react";
+
+import type { Theme } from "#app/theme/types";
+
+export type ThemeSwitchProps = {
+  fetcher: FetcherWithComponents<{
+    submission: Submission<{
+      theme: "system" | Theme;
+    }>;
+  }>;
+  userPreference?: Theme | null;
+};
+
+export const ThemeSwitch = ({ fetcher, userPreference }: ThemeSwitchProps) => {
+  const optimisticMode = useOptimisticThemeMode();
+  const [form] = useForm({
+    id: "theme-switch",
+    lastSubmission: fetcher.data?.submission,
+  });
+
+  const mode = optimisticMode ?? userPreference ?? "system";
+
+  let nextMode: "system" | Theme;
+  switch (mode) {
+    case "system":
+      nextMode = "light";
+      break;
+    case "light":
+      nextMode = "dark";
+      break;
+    case "dark":
+      nextMode = "system";
+      break;
+  }
+
+  const modeLabel = {
+    light: (
+      <Icon name="sun">
+        <span className="sr-only">Light</span>
+      </Icon>
+    ),
+    dark: (
+      <Icon name="moon">
+        <span className="sr-only">Dark</span>
+      </Icon>
+    ),
+    system: (
+      <Icon name="laptop">
+        <span className="sr-only">System</span>
+      </Icon>
+    ),
+  };
+
+  return (
+    <fetcher.Form method="POST" {...form.props}>
+      <input name="theme" type="hidden" value={nextMode} />
+      <div className="flex gap-2">
+        <button
+          className="flex h-8 w-8 cursor-pointer items-center justify-center"
+          type="submit"
+        >
+          {modeLabel[mode]}
+        </button>
+      </div>
+      <ErrorList errors={form.errors} id={form.errorId} />
+    </fetcher.Form>
+  );
+};

--- a/app/theme/theme.server.ts
+++ b/app/theme/theme.server.ts
@@ -1,23 +1,27 @@
 import * as cookie from "cookie";
 
-const cookieName = "en_theme";
-export type Theme = "light" | "dark";
+import type { Theme } from "#app/theme/types";
 
-export function getTheme(request: Request): Theme | null {
+const cookieName = "en_theme";
+
+export const getTheme = (request: Request): Theme | null => {
   const cookieHeader = request.headers.get("cookie");
+
   const parsed = cookieHeader
     ? cookie.parse(cookieHeader)[cookieName]
     : "light";
+
   if (parsed === "light" || parsed === "dark") {
     return parsed;
   }
-  return null;
-}
 
-export function setTheme(theme: Theme | "system") {
+  return null;
+};
+
+export const setTheme = (theme: Theme | "system") => {
   if (theme === "system") {
     return cookie.serialize(cookieName, "", { path: "/", maxAge: -1 });
   } else {
     return cookie.serialize(cookieName, theme, { path: "/" });
   }
-}
+};

--- a/app/theme/types.ts
+++ b/app/theme/types.ts
@@ -1,0 +1,1 @@
+export type Theme = "light" | "dark";

--- a/app/theme/useOptimisticThemeMode.ts
+++ b/app/theme/useOptimisticThemeMode.ts
@@ -1,0 +1,21 @@
+import { parse } from "@conform-to/zod";
+import { useFetchers } from "@remix-run/react";
+
+import { ThemeFormSchema } from "#app/theme/schema";
+
+/**
+ * If the user's changing their theme mode preference, this will return the
+ * value it's being changed to.
+ */
+export const useOptimisticThemeMode = () => {
+  const fetchers = useFetchers();
+  const themeFetcher = fetchers.find((f) => f.formAction === "/");
+
+  if (themeFetcher && themeFetcher.formData) {
+    const submission = parse(themeFetcher.formData, {
+      schema: ThemeFormSchema,
+    });
+
+    return submission.value?.theme;
+  }
+};

--- a/app/theme/useTheme.ts
+++ b/app/theme/useTheme.ts
@@ -1,0 +1,19 @@
+import { useOptimisticThemeMode } from "#app/theme/useOptimisticThemeMode";
+import { useHints } from "#app/utils/client-hints";
+import { useRequestInfo } from "#app/utils/request-info";
+
+/**
+ * @returns the user's theme preference, or the client hint theme if the user
+ * has not set a preference.
+ */
+export const useTheme = () => {
+  const hints = useHints();
+  const requestInfo = useRequestInfo();
+  const optimisticMode = useOptimisticThemeMode();
+
+  if (optimisticMode) {
+    return optimisticMode === "system" ? hints.theme : optimisticMode;
+  }
+
+  return requestInfo.userPrefs.theme ?? hints.theme;
+};

--- a/app/utils/user.ts
+++ b/app/utils/user.ts
@@ -1,6 +1,7 @@
 import { useRouteLoaderData } from "@remix-run/react";
 
 import type { SerializeFrom } from "@remix-run/node";
+
 import type { loader as rootLoader } from "#app/root.tsx";
 
 function isUser(


### PR DESCRIPTION
## Description

Add new components for layout building:
- Flex
- Stack
- Inline

Adjust the layout of the application to use a two-column approach once
the user is logged in.
A logged out user will still see the centered one-column layout that
will cater to the landing page and authentication use cases.

This commit also reorganizes the theme related code into #app/theme
directory.

## Screenshots

**Logged In**
![image](https://github.com/ricardocosta/bank-fe/assets/11922336/6c48ded2-92ea-4ce1-8afb-b0f04f6fd500)

**Logged Out**
![image](https://github.com/ricardocosta/bank-fe/assets/11922336/8489fc78-40d9-4297-9e50-0b89aaf891a1)


Closes #109 
